### PR TITLE
Use the actual highlight color for menubar buttons instead of white

### DIFF
--- a/colors
+++ b/colors
@@ -1,5 +1,5 @@
 [Colors:Button]
-BackgroundNormal=255,255,255
+BackgroundNormal=197,14,210
 DecorationFocus=133,0,247
 DecorationHover=189,147,249
 ForegroundNormal=217,221,227


### PR DESCRIPTION
In the current state, the background of buttons used in global menubar applets is pure white, which makes the text hard to read. This PR replaces it with the highlight color used in the KDE colorscheme to have it readable and also makes it fit the general theme much better.